### PR TITLE
Add schema validation for digit classifier artifacts

### DIFF
--- a/examples/digit-classifier/README.md
+++ b/examples/digit-classifier/README.md
@@ -44,3 +44,17 @@ All artifacts are written to the directory specified by `--output-dir` (which
 defaults to `./artifacts`).  This keeps the new analytics assets colocated with
 existing outputs, allowing dashboards or notebooks that already watch the
 artifact directory to surface the richer context automatically.
+
+## Artifact validation
+
+Each JSON artifact is validated before it is written to disk.  The helper
+functions in `run_demo.py` check for required fields, numeric ranges, and shape
+consistency so that downstream tooling can rely on a stable schema.  The
+integration test in `tests/test_digit_classifier_artifacts.py` loads the module
+directly and exercises the validators against the generated files.
+
+When adding a new export, define a corresponding `validate_*` helper near the
+top of `run_demo.py` and invoke it just before writing the JSON payload.  This
+keeps the guarantees close to the data producer and makes the validation logic
+reusable in other scripts or tests.  For more complex scenarios you can follow
+the same pattern but replace the custom checks with a Pydantic model.

--- a/examples/digit-classifier/run_demo.py
+++ b/examples/digit-classifier/run_demo.py
@@ -16,7 +16,7 @@ import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Sequence, Tuple
 
 import matplotlib
 
@@ -35,6 +35,145 @@ from sklearn.metrics import (
 )
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
+
+Number = (int, float)
+
+
+def _ensure_number(name: str, value: object) -> float:
+    if not isinstance(value, Number) or isinstance(value, bool) or not math.isfinite(float(value)):
+        raise ValueError(f"{name} must be a finite numeric value, received {value!r}")
+    return float(value)
+
+
+def _ensure_probability(name: str, value: object) -> float:
+    number = _ensure_number(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be within [0, 1], received {value!r}")
+    return number
+
+
+def _ensure_number_list(name: str, values: object, *, allow_empty: bool = False) -> List[float]:
+    if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be an iterable of numeric values")
+    result = []
+    for index, value in enumerate(values):
+        result.append(_ensure_number(f"{name}[{index}]", value))
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+def validate_metrics_payload(payload: Dict[str, object]) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("metrics payload must be a dictionary")
+
+    for key in ("train_accuracy", "test_accuracy", "classification_report"):
+        if key not in payload:
+            raise ValueError(f"metrics payload missing required key '{key}'")
+
+    for key in ("train_accuracy", "test_accuracy"):
+        _ensure_probability(key, payload[key])
+
+    report = payload["classification_report"]
+    if not isinstance(report, dict):
+        raise ValueError("classification_report must be a dictionary")
+
+    required_fields = {"precision", "recall", "f1-score", "support"}
+    for label, stats in report.items():
+        if isinstance(stats, dict):
+            missing = required_fields - stats.keys()
+            if missing:
+                raise ValueError(f"classification_report entry '{label}' missing fields {sorted(missing)}")
+            for field in ("precision", "recall", "f1-score"):
+                _ensure_probability(f"classification_report['{label}']['{field}']", stats[field])
+            support_value = stats["support"]
+            support = _ensure_number(f"classification_report['{label}']['support']", support_value)
+            if support < 0:
+                raise ValueError("classification_report support values must be non-negative")
+        else:
+            if label != "accuracy":
+                raise ValueError(f"classification_report entry '{label}' must be a mapping")
+            _ensure_probability("classification_report['accuracy']", stats)
+
+
+def validate_roc_payload(payload: Dict[str, object], expected_classes: Sequence[str]) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("roc payload must be a dictionary")
+    expected = set(expected_classes)
+    actual = set(payload.keys())
+    if expected != actual:
+        raise ValueError(f"roc payload keys {sorted(actual)} do not match expected classes {sorted(expected)}")
+
+    for class_name, stats in payload.items():
+        if not isinstance(stats, dict):
+            raise ValueError(f"roc entry '{class_name}' must be a dictionary")
+        for key in ("fpr", "tpr", "auc"):
+            if key not in stats:
+                raise ValueError(f"roc entry '{class_name}' missing key '{key}'")
+
+        fpr = _ensure_number_list(f"roc['{class_name}']['fpr']", stats["fpr"])
+        tpr = _ensure_number_list(f"roc['{class_name}']['tpr']", stats["tpr"])
+        if len(fpr) != len(tpr):
+            raise ValueError(f"roc entry '{class_name}' must have equally sized fpr and tpr arrays")
+        for index, value in enumerate(fpr):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"roc['{class_name}']['fpr'][{index}] must be within [0, 1]")
+        for index, value in enumerate(tpr):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"roc['{class_name}']['tpr'][{index}] must be within [0, 1]")
+        _ensure_probability(f"roc['{class_name}']['auc']", stats["auc"])
+
+
+def validate_training_dynamics_payload(payload: Dict[str, object]) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("training dynamics payload must be a dictionary")
+
+    for key in ("epochs", "learning_rates", "losses"):
+        if key not in payload:
+            raise ValueError(f"training dynamics payload missing key '{key}'")
+
+    epochs = payload["epochs"]
+    learning_rates = payload["learning_rates"]
+    losses = payload["losses"]
+
+    if not isinstance(epochs, Iterable) or isinstance(epochs, (str, bytes)):
+        raise ValueError("epochs must be an iterable of integers")
+    epochs_list = []
+    for index, value in enumerate(epochs):
+        if not isinstance(value, int):
+            raise ValueError(f"epochs[{index}] must be an integer")
+        epochs_list.append(value)
+    if not epochs_list:
+        raise ValueError("epochs must not be empty")
+
+    learning_rates_list = _ensure_number_list("learning_rates", learning_rates)
+    losses_list = _ensure_number_list("losses", losses)
+
+    if not (len(epochs_list) == len(learning_rates_list) == len(losses_list)):
+        raise ValueError("epochs, learning_rates, and losses must be the same length")
+
+    for index, epoch in enumerate(epochs_list):
+        if epoch != index + 1:
+            raise ValueError("epochs must start at 1 and increase by 1 for each entry")
+
+
+def validate_timing_stats_payload(payload: Dict[str, object], expected_epochs: int) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("timing stats payload must be a dictionary")
+    for key in ("total_training_time_sec", "average_epoch_time_sec", "epoch_durations_sec"):
+        if key not in payload:
+            raise ValueError(f"timing stats payload missing key '{key}'")
+
+    total = _ensure_number("total_training_time_sec", payload["total_training_time_sec"])
+    average = _ensure_number("average_epoch_time_sec", payload["average_epoch_time_sec"])
+    if total < 0 or average < 0:
+        raise ValueError("timing stats durations must be non-negative")
+
+    durations = _ensure_number_list("epoch_durations_sec", payload["epoch_durations_sec"], allow_empty=True)
+    if durations and len(durations) != expected_epochs:
+        raise ValueError("epoch_durations_sec length must match number of epochs")
+    if durations and any(value < 0 for value in durations):
+        raise ValueError("epoch durations must be non-negative")
 
 
 @dataclass
@@ -147,6 +286,7 @@ def save_metrics(
         "test_accuracy": test_accuracy,
         "classification_report": report,
     }
+    validate_metrics_payload(payload)
     with (output_dir / "metrics.json").open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
 
@@ -196,6 +336,7 @@ def maybe_save_roc_curves(
     fig.savefig(output_dir / "roc_curves.png", dpi=200)
     plt.close(fig)
 
+    validate_roc_payload(roc_data, class_names)
     with (output_dir / "roc_curves.json").open("w", encoding="utf-8") as fh:
         json.dump(roc_data, fh, indent=2)
 
@@ -215,6 +356,7 @@ def maybe_save_learning_rate_trace(
         "learning_rates": learning_rates,
         "losses": losses,
     }
+    validate_training_dynamics_payload(payload)
     with (output_dir / "training_dynamics.json").open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
 
@@ -248,6 +390,7 @@ def maybe_save_timing_stats(enabled: bool, output_dir: Path, timings: List[float
         "average_epoch_time_sec": avg_time,
         "epoch_durations_sec": timings,
     }
+    validate_timing_stats_payload(payload, expected_epochs=len(timings))
     with (output_dir / "timing_stats.json").open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
 

--- a/tests/test_digit_classifier_artifacts.py
+++ b/tests/test_digit_classifier_artifacts.py
@@ -1,0 +1,84 @@
+"""Integration tests for the digit classifier demo outputs."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytest.importorskip("matplotlib")
+pytest.importorskip("sklearn")
+
+
+def _load_run_demo_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "examples" / "digit-classifier" / "run_demo.py"
+    spec = importlib.util.spec_from_file_location("digit_classifier_run_demo", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+def _read_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_digit_classifier_artifacts(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+
+    command = [
+        sys.executable,
+        "examples/digit-classifier/run_demo.py",
+        "--output-dir",
+        str(output_dir),
+        "--epochs",
+        "5",
+        "--roc-per-class",
+        "--learning-rate-trace",
+        "--timing-stats",
+    ]
+
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    assert completed.stderr == ""
+
+    summary = json.loads(completed.stdout)
+    assert set(summary.keys()) == {"train_accuracy", "test_accuracy", "artifacts"}
+    assert isinstance(summary["artifacts"], list)
+
+    expected_artifacts = {
+        "confusion_matrix.png",
+        "metrics.json",
+        "roc_curves.json",
+        "roc_curves.png",
+        "training_dynamics.json",
+        "learning_rate_trace.png",
+        "timing_stats.json",
+        "timing_stats.png",
+    }
+    assert expected_artifacts.issubset(set(summary["artifacts"]))
+
+    run_demo = _load_run_demo_module()
+
+    metrics_payload = _read_json(output_dir / "metrics.json")
+    run_demo.validate_metrics_payload(metrics_payload)
+
+    roc_payload = _read_json(output_dir / "roc_curves.json")
+    _, _, _, _, class_names = run_demo.load_dataset(test_size=0.2, random_state=13)
+    expected_classes = [str(name) for name in class_names]
+    run_demo.validate_roc_payload(roc_payload, expected_classes)
+
+    training_payload = _read_json(output_dir / "training_dynamics.json")
+    run_demo.validate_training_dynamics_payload(training_payload)
+
+    timing_payload = _read_json(output_dir / "timing_stats.json")
+    run_demo.validate_timing_stats_payload(timing_payload, expected_epochs=5)
+
+    for filename in expected_artifacts:
+        path = output_dir / filename
+        assert path.exists(), f"expected artifact missing: {path}"


### PR DESCRIPTION
## Summary
- add JSON validation helpers to the digit classifier demo and enforce them before writing artifacts
- add an integration test that runs the demo in a temporary directory and validates the generated files
- document the validation layer and how to extend the schemas for new exports

## Testing
- pytest *(skipped: matplotlib not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ad1427648320b23710a519ded880